### PR TITLE
promptdetailpage modal

### DIFF
--- a/src/components/Comments/commentElement.jsx
+++ b/src/components/Comments/commentElement.jsx
@@ -31,7 +31,9 @@ const CommentElement = (props) => {
       <div className="flex flex-row w-full space-x-2 items-center">
         <HiUserCircle className="w-10 h-10 mr-2" />
         <div className="commentbubble">
-          <p className="text-sm mr-5 pt-1 pl-3 align-middle">{comment.content}</p>
+          <p className="text-xs mr-5 pt-1 pl-3 align-middle">
+            {comment.content}
+          </p>
           {/* <span className="text-base mr-1 text-gray-300">
           {year}.{month}.{day}
         </span> */}

--- a/src/components/Comments/index.jsx
+++ b/src/components/Comments/index.jsx
@@ -29,7 +29,7 @@ const Comment = ({ postId }) => {
   };
 
   return (
-    <div className="flex flex-col w-full mt-5 self-start h-72">
+    <div className="flex flex-col w-full self-start h-72">
       <h1 className="text-base font-semibold mt-5 mb-3">
         {commentList.length}개의 댓글
       </h1>
@@ -47,7 +47,7 @@ const Comment = ({ postId }) => {
       </div>
       {/* comment form component */}
       <form
-        className="flex items-center justify-center mt-10"
+        className="flex items-center justify-center mt-1"
         onSubmit={handleCommentSubmit}
       >
         <input

--- a/src/components/Prompts/index.jsx
+++ b/src/components/Prompts/index.jsx
@@ -1,4 +1,4 @@
-import { Link } from "react";
+import { Link } from "react-router-dom";
 
 export const SmallPrompt = ({ rank, prompt }) => {
   return (
@@ -20,11 +20,20 @@ export const MidPrompt = ({ prompt }) => {
     <div className="flex flex-col w-80 h-60 space-y-8 p-5 shadow-xl m-3 rounded-3xl border-gray-300 border bg-white">
       <div className="font-semibold text-lg">{prompt.title}</div>
       <div className="font-medium">{prompt.description}</div>
-      <div className="flex flex-row space-x-2">
-        <div className="font-bold">❤️ {prompt.like}</div>
-        <div className="font-bold">👀 {prompt.view}</div>
+      <div className="flex flex-row justify-between">
+        <div className="flex flex-row space-x-2">
+          <div className="font-bold">❤️ {prompt.like}</div>
+          <div className="font-bold">👀 {prompt.view}</div>
+        </div>
+        <div>
+          <Link
+            to="/promptdetail"
+            className="rounded-xl p-3 mb-3 font-semibold text-center text-sm text-white bg-gpt-blue"
+          >
+            프롬프트 사용하기
+          </Link>
+        </div>
       </div>
-      {/* <Link to="">이 프롬프트 사용하기</Link> */}
     </div>
   );
 };
@@ -34,16 +43,16 @@ export const MyPagePrompt = ({ prompt }) => {
     <div className="flex flex-col w-75 h-60 space-y-8 p-5 shadow-xl m-3 rounded-3xl  border-gray-300 bg-white">
       <div className="font-semibold text-lg">{prompt.title}</div>
       <div className="font-medium">{prompt.description}</div>
-      <div className="flex flex-row space-x-2 align-start">
+      <div className="flex flex-row space-x-2 self-end pb-10">
         <div className="font-bold">❤️ {prompt.like}</div>
         <div className="font-bold">👀 {prompt.view}</div>
       </div>
-      {/* <Link to="">이 프롬프트 사용하기</Link> */}
+      <Link to="/promptdetail">프롬프트 사용하기</Link>
     </div>
   );
 };
 
-export const BigPrompt = (prompt) => {
+export const BigPrompt = ({ prompt }) => {
   return (
     <div>
       <div>{prompt.title}</div>

--- a/src/components/SideBar/index.jsx
+++ b/src/components/SideBar/index.jsx
@@ -39,9 +39,9 @@ export const PromptSideBar = ({ user, prompt, comment }) => {
   // console.log(prompt);
   //console.log(user[0].username);
   return (
-    <div className="flex flex-col space-y-5 bg-white text-black rounded-tr-3xl p-5">
+    <div className="h-full flex flex-col space-y-5 bg-white text-black rounded-tr-3xl p-5">
       <Link
-        to="/:promptId/make"
+        to="/:promptmake"
         className="w-full button-b flex flex-col items-center"
       >
         내 프롬프트 만들기

--- a/src/data/category.js
+++ b/src/data/category.js
@@ -1,4 +1,5 @@
 export const category = [
+  { value: "All", label: "전체" },
   { value: "assignment", label: "과제" },
   { value: "presentation", label: "발표" },
   { value: "leisure", label: "여가" },

--- a/src/data/comments.js
+++ b/src/data/comments.js
@@ -15,8 +15,8 @@ const comments = [
   },
   {
     id: 3,
-    content: "우리팀 최고 야호",
-    like_users: [],
+    content:
+      "우리팀 최고 야호!!!!!!!이번주도 파이팅",
     author: { id: 2, username: "지우" },
     created_at: "2022-11-22T08:09:54.233976Z",
   },

--- a/src/index.css
+++ b/src/index.css
@@ -124,13 +124,15 @@ code {
 
 .commentbubble {
   position: relative;
-  width: 200px;
-  height: 40px;
+  width: 130px;
+  min-height: max-content;
   padding: 3px;
+  padding-top: 10px;
+  padding-bottom: 12px;
   background: #73a8e9;
   -webkit-border-radius: 27px;
   -moz-border-radius: 27px;
-  border-radius: 27px;
+  border-radius: 20px;
 }
 
 .commentbubble:after {
@@ -143,7 +145,7 @@ code {
   width: 0;
   z-index: 1;
   left: -10px;
-  top: 8px;
+  top: 10px;
 }
 
 /*@media screen and (max-width: 1024px) {

--- a/src/routes/HomePage.jsx
+++ b/src/routes/HomePage.jsx
@@ -13,7 +13,7 @@ const HomePage = () => {
   const [categoryList, setCategoryList] = useState([]);
   const [searchCategory, setSearchCategory] = useState([]);
   const [searchValue, setSearchValue] = useState("");
-  //const [promptList, setPromptList] = useState([]);
+  const [promptList, setPromptList] = useState([]);
   const [promptList, setPromptList] = useState(prompts);
   const [selectedCategory, setSelectedCategory] = useState("");
   const [selectedSort, setSelectedSort] = useState("");
@@ -28,17 +28,16 @@ const HomePage = () => {
     getPromptListAPI();
   }, []);
 
-    /*const getCategoryListAPI = async () => {
-      const categories = await getCategoryList();
-      console.log(categories);
-      const categoryName = categories.data.map((category) => {
-        return category.name;
-      });
-      setCategoryList(categoryName);
-      setSearchCategory(categoryName);
-    };
-    getCategoryListAPI();
-  }, []);*/
+  const getCategoryListAPI = async () => {
+    const categories = await getCategoryList();
+    console.log(categories);
+    const categoryName = categories.data.map((category) => {
+      return category.name;
+    });
+    setCategoryList(categoryName);
+    setSearchCategory(categoryName);
+  };
+  getCategoryListAPI();
 
   // const handleCategoryFilter = (e) => {
   //   const { innerText } = e.target;
@@ -64,7 +63,6 @@ const HomePage = () => {
     setSelectedCategory(e.label);
     console.log(selectedCategory);
   };
-
 
   const changeLikeOrder = () => {
     const sortedList = [...sortPromptList].sort((a, b) => {
@@ -161,11 +159,13 @@ const HomePage = () => {
                   : prompt
               )
               .filter((prompt) =>
-                selectedCategory
-                  ? prompt.category.find((category) =>
+                selectedCategory === "전체"
+                  ? prompt
+                  : selectedCategory === ""
+                  ? prompt
+                  : prompt.category.find((category) =>
                       category.name.includes(selectedCategory)
                     )
-                  : prompt
               )
               .map((prompt) => (
                 <MidPrompt key={prompt.id} prompt={prompt} />

--- a/src/routes/PromptDetailPage.jsx
+++ b/src/routes/PromptDetailPage.jsx
@@ -5,12 +5,18 @@ import comments from "../data/comments";
 import prompts from "../data/prompts";
 import users from "../data/users";
 import Select from "react-select";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
+
+import { HiUserCircle } from "react-icons/hi";
+import gpt_logo from "../assets/images/logo_gpt.png";
 
 const PromptDetailPage = () => {
   const { promptId } = useParams;
   const [prompt, setPrompt] = useState();
   const [isUser, setIsUser] = useState(users);
+
+  const [resultPage, setResultPage] = useState(false);
+  const navigate = useNavigate();
 
   // useEffect(() => {
   //   const getPromptDetailAPI = async () => {
@@ -42,56 +48,114 @@ const PromptDetailPage = () => {
         />
       </div>
 
-      <form className="flex-grow flex flex-col items-center justify-center h-4/5 w-2/3 bg-white text-black p-11 mx-20 rounded-3xl">
-        <h1 className="font-bold text-7xl text-gpt-indigo">
-          {" "}
-          {prompts[2].title}{" "}
-        </h1>
-        <h1 className="font-extrabold text-xl text-gpt-indigo mt-4">
-          {prompts[2].description}
-        </h1>
-        <br></br>
-        <div className="rounded-3xl bg-gray-200 px-8 pb-5 mx-6 h-96 w-5/6 overflow-y-scroll">
-          <div className="flex flex-col w-full justify-between">
-            <div className="button-f">자료 내용</div>
-            <input
-              required
-              type="text"
-              placeholder="요약을 원하는 자료 조사 내용을 작성해주세요"
-              className="input-c"
-            />
-            <div className="button-f">답변 길이</div>
-            <input
-              required
-              type="text"
-              placeholder="원하는 단어의 수를 숫자로 입력하세요"
-              className="input-c"
-            />
-            <div className="button-f">발표 목적</div>
-            <input
-              required
-              type="text"
-              placeholder="발표의 목적을 작성해주세요"
-              className="input-c"
-            />
-            <div className="button-f">답변 언어</div>
-            <input
-              required
-              type="text"
-              placeholder="답변을 작성할 언어를 지정해주세요"
-              className="input-c"
-            />
-          </div>
+      {resultPage ? (
+        <div className="w-screen h-screen flex flex-col items-center">
+          <form className="w-4/5 h-3/4 flex flex-col items-center bg-gray-200 text-black p-11 rounded-3xl ">
+            {/*사용자 측 프롬프트 질문*/}
+            <div className="flex justify-between mx-20">
+              <div className="bubble-a font-medium overflow-x-hidden items-center overflow-y-auto ">
+                각 지방의 내일 날씨입니다. 내일은 맑은 뒤 구름이 많이 끼겠고,
+                제주도와 울릉도 독도에는 한두 차례 눈이 오겠습니다. 아침
+                최저기온은 중서부 지방이 영하 23도에서 영하 14도, 영동과
+                남부지방은 영하 13도에서 영하 8도로 몹시 추운 날씨가 내일
+                아침까지도 계속되겠습니다. 그렇지만 낮 최고 기온은 영하 6도에서
+                영상 1도의 분포로 오늘보다 3-4도 가량 올라갈 전망입니다.
+              </div>
+              <div className="bubble-a:left" />
+              <HiUserCircle
+                size="150"
+                className="flex flex-col items-center ml-10"
+              />
+            </div>
+            <br></br>
+            {/*GPT 답변*/}
+            <div className="flex justify-between mx-20">
+              <img
+                id="gpt-logo"
+                src={gpt_logo}
+                alt="gpt_logo"
+                className="flex flex-col items-center mr-10 w-28 h-28"
+              />
+              <div className="bubble-b font-medium overscroll-y-auto line-clamp-4">
+                각 지방의 내일 날씨입니다. 내일은 맑은 뒤 구름이 많이 끼겠고,
+                제주도와 울릉도 독도에는 한두 차례 눈이 오겠습니다. 아침
+                최저기온은 중서부 지방이 영하 23도에서 영하 14도, 영동과
+                남부지방은 영하 13도에서 영하 8도로 몹시 추운 날씨가 내일
+                아침까지도 계속되겠습니다. 그렇지만 낮 최고 기온은 영하 6도에서
+                영상 1도의 분포로 오늘보다 3-4도 가량 올라갈 전망입니다. 날씨를
+                전해 드렸습니다.
+              </div>
+              <div className="bubble-b:right" />
+            </div>
+            {/*버튼*/}
+            <button
+              type="button"
+              onClick={() => {
+                setResultPage(false);
+                // console.log(resultPage);
+              }}
+              className=" bg-gpt-green text-white font-bold hover:text-black rounded-3xl text-lg py-3.5 px-20 shadow-xl"
+            >
+              나가기
+            </button>
+          </form>
         </div>
-        <br></br>
-        {/*버튼*/}
-        <button
-          type="submit"
-          className=" bg-gpt-green text-white font-bold hover:text-black rounded-3xl text-lg py-3.5 px-20 shadow-xl"
-        >
-          보내기
-        </button>
-      </form>
+      ) : (
+        <form className="flex-grow flex flex-col items-center justify-center h-4/5 w-2/3 bg-white text-black p-11 mx-20 rounded-3xl">
+          <h1 className="font-bold text-7xl text-gpt-indigo">
+            {" "}
+            {prompts[2].title}{" "}
+          </h1>
+          <h1 className="font-extrabold text-xl text-gpt-indigo mt-4">
+            {prompts[2].description}
+          </h1>
+          <br></br>
+          <div className="rounded-3xl bg-gray-200 px-8 pb-5 mx-6 h-96 w-5/6 overflow-y-scroll">
+            <div className="flex flex-col w-full justify-between">
+              <div className="button-f">자료 내용</div>
+              <input
+                required
+                type="text"
+                placeholder="요약을 원하는 자료 조사 내용을 작성해주세요"
+                className="input-c"
+              />
+              <div className="button-f">답변 길이</div>
+              <input
+                required
+                type="text"
+                placeholder="원하는 단어의 수를 숫자로 입력하세요"
+                className="input-c"
+              />
+              <div className="button-f">발표 목적</div>
+              <input
+                required
+                type="text"
+                placeholder="발표의 목적을 작성해주세요"
+                className="input-c"
+              />
+              <div className="button-f">답변 언어</div>
+              <input
+                required
+                type="text"
+                placeholder="답변을 작성할 언어를 지정해주세요"
+                className="input-c"
+              />
+            </div>
+          </div>
+          <br></br>
+          {/*버튼*/}
+          <button
+            type="submit"
+            className=" bg-gpt-green text-white font-bold hover:text-black rounded-3xl text-lg py-3.5 px-20 shadow-xl"
+            onClick={() => {
+              setResultPage(true);
+              // console.log(resultPage);
+            }}
+          >
+            보내기
+          </button>
+        </form>
+      )}
     </div>
   );
 };

--- a/src/routes/PromptResultPage.jsx
+++ b/src/routes/PromptResultPage.jsx
@@ -30,30 +30,31 @@ const PromptResultPage = () => {
     </div>
 
     <div className="w-screen h-screen flex flex-col items-center">
-    <form className="w-4/5 h-3/4 flex flex-col items-center bg-gray-200 text-black p-11 rounded-3xl ">
+      <form className="w-4/5 h-3/4 flex flex-col items-center bg-gray-200 text-black p-11 rounded-3xl ">
       {/*사용자 측 프롬프트 질문*/}
-  <div className="flex justify-between mx-20">
-  <div className="bubble-a font-medium overflow-x-hidden items-center overflow-y-auto ">각 지방의 내일 날씨입니다. 내일은 맑은 뒤 구름이 많이 끼겠고, 제주도와 울릉도 독도에는 한두 차례 눈이 오겠습니다. 아침 최저기온은 중서부 지방이 영하 23도에서 영하 14도, 영동과 남부지방은 영하 13도에서 영하 8도로 몹시 추운 날씨가 내일 아침까지도 계속되겠습니다.
-그렇지만 낮 최고 기온은 영하 6도에서 영상 1도의 분포로 오늘보다 3-4도 가량 올라갈 전망입니다.
-</div>
-  <div className="bubble-a:left"/>
-  <HiUserCircle size="150" className="flex flex-col items-center ml-10"/>
-  </div>
-  <br></br>
-{/*GPT 답변*/} 
-<div className="flex justify-between mx-20">
-<img id="gpt-logo" src={gpt_logo} alt="gpt_logo" className="flex flex-col items-center mr-10 w-28 h-28"/>
-<div className="bubble-b font-medium overscroll-y-auto line-clamp-4">각 지방의 내일 날씨입니다. 내일은 맑은 뒤 구름이 많이 끼겠고, 제주도와 울릉도 독도에는 한두 차례 눈이 오겠습니다. 아침 최저기온은 중서부 지방이 영하 23도에서 영하 14도, 영동과 남부지방은 영하 13도에서 영하 8도로 몹시 추운 날씨가 내일 아침까지도 계속되겠습니다.
-그렇지만 낮 최고 기온은 영하 6도에서 영상 1도의 분포로 오늘보다 3-4도 가량 올라갈 전망입니다.
-날씨를 전해 드렸습니다.</div>
-  <div className="bubble-b:right"/>
-  </div>
-  {/*버튼*/}
-  <button type="button" onclick="history.back()" className=" bg-gpt-green text-white font-bold hover:text-black rounded-3xl text-lg py-3.5 px-20 shadow-xl">
-  나가기
-  </button>
-  </form>
-  </div></div>
+      <div className="flex justify-between mx-20">
+        <div className="bubble-a font-medium overflow-x-hidden items-center overflow-y-auto ">각 지방의 내일 날씨입니다. 내일은 맑은 뒤 구름이 많이 끼겠고, 제주도와 울릉도 독도에는 한두 차례 눈이 오겠습니다. 아침 최저기온은 중서부 지방이 영하 23도에서 영하 14도, 영동과 남부지방은 영하 13도에서 영하 8도로 몹시 추운 날씨가 내일 아침까지도 계속되겠습니다.
+      그렇지만 낮 최고 기온은 영하 6도에서 영상 1도의 분포로 오늘보다 3-4도 가량 올라갈 전망입니다.
+      </div>
+      <div className="bubble-a:left"/>
+      <HiUserCircle size="150" className="flex flex-col items-center ml-10"/>
+      </div>
+      <br></br>
+      {/*GPT 답변*/} 
+      <div className="flex justify-between mx-20">
+        <img id="gpt-logo" src={gpt_logo} alt="gpt_logo" className="flex flex-col items-center mr-10 w-28 h-28"/>
+        <div className="bubble-b font-medium overscroll-y-auto line-clamp-4">각 지방의 내일 날씨입니다. 내일은 맑은 뒤 구름이 많이 끼겠고, 제주도와 울릉도 독도에는 한두 차례 눈이 오겠습니다. 아침 최저기온은 중서부 지방이 영하 23도에서 영하 14도, 영동과 남부지방은 영하 13도에서 영하 8도로 몹시 추운 날씨가 내일 아침까지도 계속되겠습니다.
+        그렇지만 낮 최고 기온은 영하 6도에서 영상 1도의 분포로 오늘보다 3-4도 가량 올라갈 전망입니다.
+        날씨를 전해 드렸습니다.</div>
+        <div className="bubble-b:right"/>
+        </div>
+        {/*버튼*/}
+        <button type="button" onclick="history.back()" className=" bg-gpt-green text-white font-bold hover:text-black rounded-3xl text-lg py-3.5 px-20 shadow-xl">
+          나가기
+          </button>
+          </form>
+          </div>
+          </div>
   );
 };
 


### PR DESCRIPTION
1. 프롬프트 디테일 페이지에서 보내기 누르면 프롬프트 결과 화면 보여주기(현재 하드코딩 되어있는 상태)
2. 프롬프트 결과화면에서 나가기 누르면 프롬프트 디테일 화면으로 바뀜
3. 홈페이지 미들프롬프트에 "프롬프트 사용하기" 버튼 추가 => 버튼 누르면 프롬프트 디테일 페이지로 이동
4. 사이드바 댓글 길어지면 버블도 함께 늘어나게 처리
5. 홈페이지 카테고리에 "전체" 카테고리 추가 및 클릭 시 전체 프롬프트 보이게 수정

1번과 2번으로 인해 promptresult 페이지가 따로 있을 필요성이 사라진 것 같아용